### PR TITLE
Add extrusion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Options:
   -c, --color [hex=0xffffff00]  RGBA color to use for the background color, only matters if there is margin or spacing (default: transparent white)
   -m, --margin [integer=0]      number of pixels between tiles and the edge of the tileset image (default: 0)
   -s, --spacing [integer=0]     number of pixels between neighboring tiles (default: 0)
+  -e, --extrusion [integer=1]   number of pixels to extrude by (default: 1)
   -h, --help                    output usage information
 ```
 

--- a/bin/tile-extruder
+++ b/bin/tile-extruder
@@ -25,6 +25,7 @@ program
     0
   )
   .option("-s, --spacing [integer=0]", "number of pixels between neighboring tiles", toInt, 0)
+  .option("-e, --extrusion [integer=1]", "number of pixels to extrude by", toInt, 1)
   .parse(process.argv);
 
 const {
@@ -32,6 +33,7 @@ const {
   tileHeight,
   margin,
   spacing,
+  extrusion,
   color,
   input: inputPath,
   output: outputPath
@@ -54,4 +56,4 @@ if (!outputPath) {
   program.help();
 }
 
-extrudeTilesetToImage(tileWidth, tileHeight, inputPath, outputPath, { margin, spacing, color });
+extrudeTilesetToImage(tileWidth, tileHeight, inputPath, outputPath, { margin, spacing, extrusion, color });

--- a/src/copy-pixels.js
+++ b/src/copy-pixels.js
@@ -21,4 +21,25 @@ function copyPixels(srcImage, srcX, srcY, srcW, srcH, destImage, destX, destY) {
   });
 }
 
-module.exports = copyPixels;
+/**
+ * This copies the source pixel to every pixel in the destination rectangle without any alpha blending.
+ * @param {Image} srcImage A Jimp image to copy pixel from.
+ * @param {number} srcX X position of the source pixel.
+ * @param {number} srcY Y position of the source pixel.
+ * @param {Image} destImage A Jimp image to paste the pixel to.
+ * @param {number} destX X position to start pasting to (left).
+ * @param {number} destY Y position to start pasting to (top).
+ * @param {number} destW The width of the destination region.
+ * @param {number} destH The height of the destination region.
+ */
+function copyPixelToRect(srcImage, srcX, srcY, destImage, destX, destY, destW, destH) {
+  const srcIndex = srcImage.getPixelIndex(srcX, srcY);
+  destImage.scan(destX, destY, destW, destH, (curDestX, curDestY, curDestIndex) => {
+    destImage.bitmap.data[curDestIndex + 0] = srcImage.bitmap.data[srcIndex + 0];
+    destImage.bitmap.data[curDestIndex + 1] = srcImage.bitmap.data[srcIndex + 1];
+    destImage.bitmap.data[curDestIndex + 2] = srcImage.bitmap.data[srcIndex + 2];
+    destImage.bitmap.data[curDestIndex + 3] = srcImage.bitmap.data[srcIndex + 3];
+  });
+}
+
+module.exports = { copyPixels, copyPixelToRect };


### PR DESCRIPTION
In certain scenarios it is desired to have extrusion by more than 1px (e.g. when heavily zooming the tilemap out). This PR adds `--extrusion` option which allows to set any number of pixels to extrude by. It defaults to 1px, respecting backwards compatibility.

All existing tests are passing. I didn't add any more, but tested manually in our production app, seems to work fine. Might add some new tests if desired.