### PR TITLE
Normalize tile-extruder line endings

### DIFF
--- a/bin/tile-extruder
+++ b/bin/tile-extruder
@@ -63,3 +63,4 @@ extrudeTilesetToImage(tileWidth, tileHeight, inputPath, outputPath, {
   extrusion,
   color,
 });
+


### PR DESCRIPTION
Trying to create a fix for Issue #10 

locally it has the "right" line breaks, but hard to tell from "diff" weather this is actually a fix 😞 