### PR TITLE
Fix up next config for production builds of shader web app

### DIFF
--- a/packages/tile-extruder-web-app/next.config.ts
+++ b/packages/tile-extruder-web-app/next.config.ts
@@ -1,6 +1,13 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  webpack: (config) => {
+    config.module.rules.push({
+      test: /\.(glsl|vs|fs|vert|frag)$/,
+      use: "raw-loader",
+    });
+    return config;
+  },
   turbopack: {
     rules: {
       "*.{glsl,vs,fs,vert,frag}": {


### PR DESCRIPTION
# Description

Need to configure webpack AND turbopack to have glsl files load in dev + prod

## What changed

add webpack config to next config

## Test plan

PR deploy works: https://tile-extruder-9nk4p8gwy-mikewesthads-projects.vercel.app/