### PR TITLE
Web app: enhance form with name, size and tile visualization

### DIFF
--- a/packages/tile-extruder-web-app/src/app/extrude/form/TilesetImageProvider.tsx
+++ b/packages/tile-extruder-web-app/src/app/extrude/form/TilesetImageProvider.tsx
@@ -5,6 +5,7 @@ import { useObjectUrl } from "@/app/extrude/form/useObjectUrl";
 
 interface TilesetImageContextType {
   imageFile: File | null;
+  imageName: string;
   imageObjectUrl: string | null;
   setImageFile: (imageFile: File | null) => void;
   isImageLoading: boolean;
@@ -13,10 +14,13 @@ interface TilesetImageContextType {
 
 const TilesetImageContext = createContext<TilesetImageContextType | undefined>(undefined);
 
+const defaultImageName = "unknown.png";
+
 export function TilesetImageProvider({ children }: { children: ReactNode }) {
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [isImageLoading, setIsImageLoading] = useState(false);
   const [imageElement, setImageElement] = useState<HTMLImageElement | null>(null);
+  const [imageName, setImageName] = useState<string>(defaultImageName);
   const { setObjectUrlFromFile, objectUrl: imageObjectUrl, clearObjectUrl } = useObjectUrl();
 
   useEffect(() => {
@@ -39,10 +43,12 @@ export function TilesetImageProvider({ children }: { children: ReactNode }) {
     if (newImage) {
       setObjectUrlFromFile(newImage);
       setImageFile(newImage);
+      setImageName(newImage.name ?? "unknown.png");
     } else {
       clearObjectUrl();
       setImageElement(null);
       setImageFile(null);
+      setImageName(defaultImageName);
     }
   };
 
@@ -50,6 +56,7 @@ export function TilesetImageProvider({ children }: { children: ReactNode }) {
     <TilesetImageContext.Provider
       value={{
         imageFile,
+        imageName,
         imageObjectUrl,
         setImageFile: handleSetImage,
         isImageLoading,

--- a/packages/tile-extruder-web-app/src/app/extrude/gridProgram/createGridProgram.ts
+++ b/packages/tile-extruder-web-app/src/app/extrude/gridProgram/createGridProgram.ts
@@ -1,0 +1,143 @@
+import { createGlslProgram } from "@/app/webgl/createShader";
+import vertexShaderSource from "./vertexShader.glsl";
+import fragmentShaderSource from "./fragmentShader.glsl";
+import { makeSuccess, makeError, isError, Outcome } from "ts-outcome";
+import { createTexture } from "@/app/webgl/createTexture";
+
+export interface GridProgram {
+  render: () => void;
+  destroy: () => void;
+}
+
+interface GridOptions {
+  tileWidth: number;
+  tileHeight: number;
+  margin: number;
+  spacing: number;
+}
+
+export function createGridProgram({
+  gl,
+  tilesetImage,
+  options,
+  showGrid,
+  gridColor,
+}: {
+  gl: WebGL2RenderingContext;
+  tilesetImage: HTMLImageElement;
+  options: GridOptions;
+  showGrid: boolean;
+  gridColor: { r: number; g: number; b: number; a: number };
+}): Outcome<GridProgram, Error> {
+  const programResult = createGlslProgram({ gl, vertexShaderSource, fragmentShaderSource });
+
+  if (isError(programResult)) {
+    return makeError(programResult.error);
+  }
+
+  let isDestroyed = false;
+  const program = programResult.value;
+
+  const tilesetImageTexture = createTexture({ gl, image: tilesetImage });
+
+  const positionLocation = gl.getAttribLocation(program, "a_position");
+  const texCoordLocation = gl.getAttribLocation(program, "a_texCoord");
+  const tilesetImageLocation = gl.getUniformLocation(program, "u_tilesetImage");
+  const tileSizeLocation = gl.getUniformLocation(program, "u_tileSize");
+  const canvasSizeLocation = gl.getUniformLocation(program, "u_canvasSize");
+  const spacingLocation = gl.getUniformLocation(program, "u_spacing");
+  const marginLocation = gl.getUniformLocation(program, "u_margin");
+  const gridColorLocation = gl.getUniformLocation(program, "u_gridColor");
+  const showGridLocation = gl.getUniformLocation(program, "u_showGrid");
+
+  // Vertex positions for a quad covering the render area. (-1, -1) is the is
+  // the bottom left in clip space.
+  // Set up a new buffer on the GPU.
+  const positionBuffer = gl.createBuffer();
+  // Set that new position buffer as the active ARRAY_BUFFER.
+  gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+  // Upload vertex positions to active ARRAY_BUFFER to form a triangle strip.
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array([
+      // Bottom left
+      -1, -1,
+      // Bottom right
+      1, -1,
+      // Top left
+      -1, 1,
+      // Top right
+      1, 1,
+    ]),
+    gl.STATIC_DRAW
+  );
+
+  // Matching texture coordinates for the positions. (0, 0) is the top left in
+  // our fragment shader.
+  const texCoordBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, texCoordBuffer);
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array([
+      // Bottom left
+      0, 1,
+      // Bottom right
+      1, 1,
+      // Top left
+      0, 0,
+      // Top right
+      1, 0,
+    ]),
+    gl.STATIC_DRAW
+  );
+
+  const vertexArrayObject = gl.createVertexArray();
+  gl.bindVertexArray(vertexArrayObject);
+
+  gl.enableVertexAttribArray(positionLocation);
+  gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+  gl.vertexAttribPointer(positionLocation, 2, gl.FLOAT, false, 0, 0);
+
+  gl.enableVertexAttribArray(texCoordLocation);
+  gl.bindBuffer(gl.ARRAY_BUFFER, texCoordBuffer);
+  gl.vertexAttribPointer(texCoordLocation, 2, gl.FLOAT, false, 0, 0);
+
+  return makeSuccess({
+    render: () => {
+      if (isDestroyed) {
+        return;
+      }
+
+      gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
+      gl.clearColor(0, 0, 0, 0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.useProgram(program);
+      gl.bindVertexArray(vertexArrayObject);
+
+      gl.activeTexture(gl.TEXTURE0);
+      gl.bindTexture(gl.TEXTURE_2D, tilesetImageTexture);
+      gl.uniform1i(tilesetImageLocation, 0);
+
+      gl.uniform2f(tileSizeLocation, options.tileWidth, options.tileHeight);
+      gl.uniform1f(spacingLocation, options.spacing);
+      gl.uniform1f(marginLocation, options.margin);
+      gl.uniform2f(canvasSizeLocation, gl.canvas.width, gl.canvas.height);
+      gl.uniform4f(gridColorLocation, gridColor.r, gridColor.g, gridColor.b, gridColor.a);
+      gl.uniform1f(showGridLocation, showGrid ? 1.0 : 0.0);
+
+      gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+    },
+    destroy: () => {
+      if (isDestroyed) {
+        return;
+      }
+
+      isDestroyed = true;
+      gl.deleteBuffer(positionBuffer);
+      gl.deleteBuffer(texCoordBuffer);
+      gl.deleteVertexArray(vertexArrayObject);
+      gl.deleteTexture(tilesetImageTexture);
+      gl.deleteProgram(program);
+    },
+  });
+}

--- a/packages/tile-extruder-web-app/src/app/extrude/gridProgram/fragmentShader.glsl
+++ b/packages/tile-extruder-web-app/src/app/extrude/gridProgram/fragmentShader.glsl
@@ -1,0 +1,45 @@
+#version 300 es
+
+precision highp float;
+
+in vec2 v_texCoord;
+
+uniform sampler2D u_tilesetImage;
+uniform vec2 u_tileSize;
+uniform vec2 u_canvasSize;
+uniform float u_margin;
+uniform float u_spacing;
+uniform vec4 u_gridColor;
+uniform bool u_showGrid;
+
+out vec4 fragColor;
+
+void main() {
+  vec2 pixelPos = v_texCoord * u_canvasSize;
+  vec2 adjustedTileSize = u_tileSize + u_spacing;
+  vec2 adjustedPixelPos = pixelPos - u_margin;
+  vec2 posInTileCoords = floor(adjustedPixelPos / adjustedTileSize);
+  vec2 pixelPosInTile = adjustedPixelPos - (posInTileCoords * adjustedTileSize);
+  vec2 uvPos = u_margin + pixelPosInTile + posInTileCoords * (u_tileSize + u_spacing);
+  vec2 texCoord = uvPos / u_canvasSize;
+  vec4 imageColor = texture(u_tilesetImage, texCoord);
+
+  // If in margin, return image color directly.
+  if(pixelPos.x < u_margin || pixelPos.x >= u_canvasSize.x - u_margin ||
+    pixelPos.y < u_margin || pixelPos.y >= u_canvasSize.y - u_margin) {
+    fragColor = imageColor;
+    return;
+  }
+
+  // If in the grid line, mix the image color with the grid color.
+  if(u_showGrid && pixelPosInTile.x >= 0.0f && pixelPosInTile.x < u_tileSize.x &&
+    pixelPosInTile.y >= 0.0f && pixelPosInTile.y < u_tileSize.y &&
+    (pixelPosInTile.x < 1.0f || pixelPosInTile.x > u_tileSize.x - 1.0f ||
+    pixelPosInTile.y < 1.0f || pixelPosInTile.y > u_tileSize.y - 1.0f)) {
+    fragColor = mix(imageColor, u_gridColor, 0.7f);
+    return;
+  }
+
+  // Otherwise, return the image color.
+  fragColor = imageColor;
+}

--- a/packages/tile-extruder-web-app/src/app/extrude/gridProgram/vertexShader.glsl
+++ b/packages/tile-extruder-web-app/src/app/extrude/gridProgram/vertexShader.glsl
@@ -1,0 +1,10 @@
+#version 300 es
+
+in vec2 a_position;
+in vec2 a_texCoord;
+out vec2 v_texCoord;
+
+void main() {
+  gl_Position = vec4(a_position.x, a_position.y, 0, 1);
+  v_texCoord = a_texCoord;
+}


### PR DESCRIPTION
# Description

Improving the UI with:
- filename preview
- image size below tileset / extruded tileset
- optional visualization of tile settings as a grid overlay on the tileset to help folks visually check what they enter

## What changed

Before:
![image](https://github.com/user-attachments/assets/0238f91b-2b75-4eec-ac49-280c3f08cb1c)

After:
![image](https://github.com/user-attachments/assets/3130c894-a33f-43d6-a247-e37255f4a8f8)


## Test plan

- load up an image
- should see the image name + dimensions below the tileset preview
- should see dimensions below the extrusion preview
- should be able to toggle on/off a grid visualization