### PR TITLE
Web app: improvements to form (animated tile viz, usability fixes)

### DIFF
--- a/packages/tile-extruder-web-app/src/app/ImageDropZone.tsx
+++ b/packages/tile-extruder-web-app/src/app/ImageDropZone.tsx
@@ -16,7 +16,11 @@ export default function ImageDropZone({ onDrop, children, className = "" }: Imag
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleClick = useCallback(() => {
-    fileInputRef.current?.click();
+    if (fileInputRef.current) {
+      // Clear input value to allow re-uploading the same file.
+      fileInputRef.current.value = "";
+      fileInputRef.current.click();
+    }
   }, []);
 
   const handleFileChange = useCallback(

--- a/packages/tile-extruder-web-app/src/app/extrude/form/InfoTooltip.tsx
+++ b/packages/tile-extruder-web-app/src/app/extrude/form/InfoTooltip.tsx
@@ -1,0 +1,25 @@
+import { Button, OverlayArrow, Tooltip, TooltipTrigger } from "react-aria-components";
+import { MdInfoOutline } from "react-icons/md";
+import { ReactNode } from "react";
+
+interface InfoTooltipProps {
+  children: ReactNode;
+}
+
+export function InfoTooltip({ children }: InfoTooltipProps) {
+  return (
+    <TooltipTrigger delay={100}>
+      <Button className="text-gray-700 hover:text-gray-900">
+        <MdInfoOutline className="h-4 w-4" />
+      </Button>
+      <Tooltip className="bg-white border border-gray-200 rounded-lg shadow-lg p-4 max-w-xs">
+        <OverlayArrow>
+          <svg width={8} height={8} viewBox="0 0 8 8">
+            <path d="M0 0 L4 4 L8 0" fill="white" />
+          </svg>
+        </OverlayArrow>
+        {children}
+      </Tooltip>
+    </TooltipTrigger>
+  );
+}

--- a/packages/tile-extruder-web-app/src/app/extrude/form/IntegerField.tsx
+++ b/packages/tile-extruder-web-app/src/app/extrude/form/IntegerField.tsx
@@ -1,8 +1,7 @@
 import { UseFormRegister, FieldErrors } from "react-hook-form";
 import { FormValues } from "./ExtruderForm";
-import { Button, OverlayArrow, Tooltip, TooltipTrigger } from "react-aria-components";
-import { MdInfoOutline } from "react-icons/md";
 import { ReactNode } from "react";
+import { InfoTooltip } from "./InfoTooltip";
 
 interface IntegerFieldProps {
   name: keyof FormValues;
@@ -27,21 +26,7 @@ export function IntegerField({
     <div>
       <div className="flex items-center gap-1 mb-1">
         <label className="text-sm font-medium text-gray-900">{label}</label>
-        {tooltip && (
-          <TooltipTrigger delay={100}>
-            <Button className="text-gray-700 hover:text-gray-900">
-              <MdInfoOutline className="h-4 w-4" />
-            </Button>
-            <Tooltip className="bg-white border border-gray-200 rounded-lg shadow-lg p-4 max-w-xs">
-              <OverlayArrow>
-                <svg width={8} height={8} viewBox="0 0 8 8">
-                  <path d="M0 0 L4 4 L8 0" fill="white" />
-                </svg>
-              </OverlayArrow>
-              {tooltip}
-            </Tooltip>
-          </TooltipTrigger>
-        )}
+        {tooltip ? <InfoTooltip>{tooltip}</InfoTooltip> : null}
       </div>
       <input
         type="number"

--- a/packages/tile-extruder-web-app/src/app/extrude/gridProgram/fragmentShader.glsl
+++ b/packages/tile-extruder-web-app/src/app/extrude/gridProgram/fragmentShader.glsl
@@ -1,4 +1,5 @@
 #version 300 es
+#define PI 3.1415926538
 
 precision highp float;
 
@@ -11,6 +12,7 @@ uniform float u_margin;
 uniform float u_spacing;
 uniform vec4 u_gridColor;
 uniform bool u_showGrid;
+uniform float u_time;
 
 out vec4 fragColor;
 
@@ -36,7 +38,10 @@ void main() {
     pixelPosInTile.y >= 0.0f && pixelPosInTile.y < u_tileSize.y &&
     (pixelPosInTile.x < 1.0f || pixelPosInTile.x > u_tileSize.x - 1.0f ||
     pixelPosInTile.y < 1.0f || pixelPosInTile.y > u_tileSize.y - 1.0f)) {
-    fragColor = mix(imageColor, u_gridColor, 0.7f);
+    // Generate a value between 0 and 1 that will take 2 seconds.
+    float t = 0.5f + 0.5f * sin(u_time * 0.5f * PI);
+    float gridColorAmount = mix(0.1f, 0.8f, t);
+    fragColor = mix(imageColor, u_gridColor, gridColorAmount);
     return;
   }
 

--- a/packages/tile-extruder-web-app/src/app/webgl/createRafLoop.ts
+++ b/packages/tile-extruder-web-app/src/app/webgl/createRafLoop.ts
@@ -1,0 +1,41 @@
+/**
+ * Creates a requestAnimationFrame loop that provides timing information to a callback.
+ * The loop can be started and stopped as needed.
+ */
+export function createRafLoop(cb: (time: { elapsedMs: number; currentMs: number }) => void) {
+  let rafId: number | null = null;
+  let startTime: number | null = null;
+
+  const loop = (time: number) => {
+    if (!startTime) {
+      startTime = time;
+    }
+    cb({
+      elapsedMs: time - startTime,
+      currentMs: time,
+    });
+    rafId = requestAnimationFrame(loop);
+  };
+
+  return {
+    /**
+     * Starts the animation loop if it's not already running.
+     * Resets the elapsed time counter.
+     */
+    start: () => {
+      if (!rafId) {
+        startTime = null;
+        rafId = requestAnimationFrame(loop);
+      }
+    },
+    /**
+     * Stops the animation loop if it's running.
+     */
+    stop: () => {
+      if (rafId) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+    },
+  };
+}


### PR DESCRIPTION
# Description

Couple improvements to the web app extrusion form

## What changed

- fixed bug where you couldn't re-upload the same image after clearing the form (`packages/tile-extruder-web-app/src/app/ImageDropZone.tsx`)
- extract a common `packages/tile-extruder-web-app/src/app/extrude/form/InfoTooltip.tsx` for later
- add an error message to `packages/tile-extruder-web-app/src/app/extrude/form/ExtruderForm.tsx` when the form dimensions are invalid
- update the tile grid viz to be animated and default on to help w/ making sense of the form settings for new users


https://github.com/user-attachments/assets/ab5430b1-e629-483e-9adf-6c5e625fcc72



## Test plan

- bug fix - load an image => clear => load the same image => should work
- invalid dims - load an image => set the width and height to the wrong values => see error message
- animated grid - load an image => see flashing grid that updates when the form changes