### PR TITLE
Web app: bug fixes

### DIFF
--- a/packages/tile-extruder-web-app/src/app/components/ImageDropZone.module.css
+++ b/packages/tile-extruder-web-app/src/app/components/ImageDropZone.module.css
@@ -1,5 +1,4 @@
 .dropzone {
-  height: 100%;
   text-align: center;
   cursor: pointer;
   display: flex;

--- a/packages/tile-extruder-web-app/src/app/components/WebGL2Canvas.tsx
+++ b/packages/tile-extruder-web-app/src/app/components/WebGL2Canvas.tsx
@@ -2,13 +2,31 @@ import { useRef, useEffect } from "react";
 
 /**
  * Wrapper around a canvas element that triggers `onContextChange` when a new
- * webgl2 context is created (or destroyed).
+ * webgl2 context is created (or destroyed), which can then be used to set a
+ * state variable.
+ *
+ * @example
+ * const [ctx, setCtx] = useState<WebGL2RenderingContext | null>(null);
+ * const [shouldRender, setShouldRender] = useState(false);
+ *
+ * useEffect(() => {
+ *  // Draw stuff with ctx.
+ *
+ *  return () => {
+ *    // Do your cleanup.
+ *  }
+ * }, [ctx])
+ *
+ * return <>
+ *  <Checkbox onToggle={() => setShouldRender(!shouldRender)} />
+ *  {shouldRender ? <WebGL2Canvas onContextChange={setShaderGl} /> : null}
+ * </>
  */
 export function WebGL2Canvas({
   onContextChange,
   ...canvasProps
 }: {
-  onContextChange: (gl: WebGL2RenderingContext | null) => void;
+  onContextChange: (ctx: WebGL2RenderingContext | null) => void;
 } & React.ComponentPropsWithoutRef<"canvas">) {
   const ref = useRef<HTMLCanvasElement>(null);
   const onContextChangeRef = useRef(onContextChange);
@@ -22,14 +40,14 @@ export function WebGL2Canvas({
       return;
     }
 
-    const gl = canvas.getContext("webgl2");
-    if (!gl) {
+    const ctx = canvas.getContext("webgl2");
+    if (!ctx) {
       onContextChangeRef.current(null);
       console.error("WebGL not supported");
       return;
     }
 
-    onContextChangeRef.current(gl);
+    onContextChangeRef.current(ctx);
 
     return () => {
       onContextChangeRef.current(null);

--- a/packages/tile-extruder-web-app/src/app/components/WebGL2Canvas.tsx
+++ b/packages/tile-extruder-web-app/src/app/components/WebGL2Canvas.tsx
@@ -1,0 +1,40 @@
+import { useRef, useEffect } from "react";
+
+/**
+ * Wrapper around a canvas element that triggers `onContextChange` when a new
+ * webgl2 context is created (or destroyed).
+ */
+export function WebGL2Canvas({
+  onContextChange,
+  ...canvasProps
+}: {
+  onContextChange: (gl: WebGL2RenderingContext | null) => void;
+} & React.ComponentPropsWithoutRef<"canvas">) {
+  const ref = useRef<HTMLCanvasElement>(null);
+  const onContextChangeRef = useRef(onContextChange);
+
+  onContextChangeRef.current = onContextChange;
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) {
+      onContextChangeRef.current(null);
+      return;
+    }
+
+    const gl = canvas.getContext("webgl2");
+    if (!gl) {
+      onContextChangeRef.current(null);
+      console.error("WebGL not supported");
+      return;
+    }
+
+    onContextChangeRef.current(gl);
+
+    return () => {
+      onContextChangeRef.current(null);
+    };
+  }, []);
+
+  return <canvas ref={ref} {...canvasProps} />;
+}

--- a/packages/tile-extruder-web-app/src/app/extrude/form/ExtruderForm.tsx
+++ b/packages/tile-extruder-web-app/src/app/extrude/form/ExtruderForm.tsx
@@ -12,6 +12,7 @@ import { MdClose, MdError, MdOutlineImage } from "react-icons/md";
 import Image from "next/image";
 import { Button } from "@/app/components/Button";
 import styles from "./ExtruderForm.module.css";
+import { WebGL2Canvas } from "@/app/components/WebGL2Canvas";
 
 export type FormValues = {
   tileWidth: number;
@@ -84,8 +85,8 @@ function useCheckDimensions({ width, height }: { width: number; height: number }
 }
 
 export default function ExtruderForm() {
-  const sourceCanvasRef = useRef<HTMLCanvasElement>(null);
-  const shaderCanvasRef = useRef<HTMLCanvasElement>(null);
+  const [sourceGl, setSourceGl] = useState<WebGL2RenderingContext | null>(null);
+  const [shaderGl, setShaderGl] = useState<WebGL2RenderingContext | null>(null);
   const shaderProgramRef = useRef<ShaderProgram | null>(null);
   const { imageElement, isImageLoading, setImageFile, imageName } = useTilesetImage();
   const [showGrid, setShowGrid] = useState(true);
@@ -108,25 +109,20 @@ export default function ExtruderForm() {
 
   const dimensionError = useCheckDimensions(extrudedShaderDimensions);
 
-  // Update the tileset preview canvas when the image element changes.
+  // Update the tileset preview canvas when the image element or GL context
+  // changes.
   useEffect(() => {
     async function updateCanvases() {
       const image = imageElement;
-      if (!sourceCanvasRef.current || !image) {
+      if (!sourceGl || !image) {
         return;
       }
 
-      const sourceCanvas = sourceCanvasRef.current;
-      sourceCanvas.width = image.width;
-      sourceCanvas.height = image.height;
-      const gl = sourceCanvas.getContext("webgl2");
-      if (!gl) {
-        console.error("WebGL not supported");
-        return;
-      }
+      sourceGl.canvas.width = image.width;
+      sourceGl.canvas.height = image.height;
 
       const programResult = createGridProgram({
-        gl,
+        gl: sourceGl,
         tilesetImage: image,
         options: {
           tileWidth: options.tileWidth,
@@ -151,32 +147,20 @@ export default function ExtruderForm() {
     }
 
     updateCanvases();
-  }, [imageElement, options, showGrid]);
+  }, [imageElement, options, showGrid, sourceGl]);
 
-  // Update the extruded tileset preview canvas when the image element changes.
+  // Update the extruded tileset preview canvas when the image element or GL context changes
   useEffect(() => {
-    if (!imageElement) {
+    if (!imageElement || !hasValidValues || !shaderGl) {
       return;
     }
 
-    if (!hasValidValues) {
-      return;
-    }
-
-    const canvas = shaderCanvasRef.current;
-    if (!canvas) return;
-
-    const gl = canvas.getContext("webgl2");
-    if (!gl) {
-      console.error("WebGL not supported");
-      return;
-    }
     const { width, height } = calculateExtrudedTilesetDimensions(imageElement, options);
-    canvas.width = width;
-    canvas.height = height;
+    shaderGl.canvas.width = width;
+    shaderGl.canvas.height = height;
 
     const programResult = createExtrusionProgram({
-      gl,
+      gl: shaderGl,
       tilesetImage: imageElement,
       options: {
         tileWidth: options.tileWidth,
@@ -194,21 +178,23 @@ export default function ExtruderForm() {
 
     shaderProgramRef.current = programResult.value;
     const { render, destroy } = programResult.value;
-
     render();
 
-    return destroy;
-  }, [imageElement, hasValidValues, options]);
+    return () => {
+      destroy();
+      shaderProgramRef.current = null;
+    };
+  }, [imageElement, hasValidValues, options, shaderGl]);
 
   const handleDownload = () => {
-    if (!shaderCanvasRef.current || !shaderProgramRef.current) return;
+    if (!shaderGl || !shaderProgramRef.current) return;
 
     // Ensure the canvas is up to date before downloading.
     shaderProgramRef.current.render();
 
     const link = document.createElement("a");
     link.download = "extruded-tileset.png";
-    link.href = shaderCanvasRef.current.toDataURL("image/png");
+    link.href = (shaderGl.canvas as HTMLCanvasElement).toDataURL("image/png");
     link.click();
   };
 
@@ -243,7 +229,11 @@ export default function ExtruderForm() {
             ) : (
               <>
                 {imageElement ? (
-                  <canvas ref={sourceCanvasRef} className={styles.imageCanvas} />
+                  <WebGL2Canvas
+                    onContextChange={setSourceGl}
+                    className={styles.imageCanvas}
+                    data-cy="source-tileset-canvas"
+                  />
                 ) : (
                   <div className={styles.dropzoneContent}>
                     <MdOutlineImage size={32} />
@@ -270,8 +260,8 @@ export default function ExtruderForm() {
           </div>
           <div className={styles.image}>
             {imageElement && hasValidValues ? (
-              <canvas
-                ref={shaderCanvasRef}
+              <WebGL2Canvas
+                onContextChange={setShaderGl}
                 className={styles.imageCanvas}
                 data-cy="extruded-tileset-canvas"
               />

--- a/packages/tile-extruder-web-app/src/app/info/page.tsx
+++ b/packages/tile-extruder-web-app/src/app/info/page.tsx
@@ -21,7 +21,10 @@ export default function InfoPage() {
       />
       <p>
         You can read more about the bleeding problem and solution{" "}
-        <Link href="https://web.archive.org/web/20180411151113/http://rotorz.com/unity/tile-system/docs/edge-correction">
+        <Link
+          target="_blank"
+          href="https://web.archive.org/web/20180411151113/http://rotorz.com/unity/tile-system/docs/edge-correction"
+        >
           here
         </Link>
         . The TL DR is that there are many ways this type of rendering artifact can occur, e.g. from
@@ -42,7 +45,10 @@ export default function InfoPage() {
       <p>
         You can extrude a tileset using this web app, or via the sister command line tool (CLI). For
         more info on the CLI, see the{" "}
-        <Link href="https://github.com/sporadic-labs/tile-extruder">GitHub repository</Link>.
+        <Link target="_blank" href="https://github.com/sporadic-labs/tile-extruder">
+          GitHub repository
+        </Link>
+        .
       </p>
       <h2 className={styles.sectionTitle}>Using an Extruded Tileset</h2>
       <p>
@@ -64,7 +70,10 @@ export default function InfoPage() {
         <li>
           If you&apos;d rather leave your Tiled file alone, you can just adjust things on the Phaser
           side. See this{" "}
-          <Link href="https://github.com/sporadic-labs/tile-extruder/tree/main/packages/phaser-example">
+          <Link
+            target="_blank"
+            href="https://github.com/sporadic-labs/tile-extruder/tree/main/packages/phaser-example"
+          >
             example
           </Link>
           . You want to load the extruded tileset image, and then when you create your tileset,

--- a/packages/tile-extruder-web-app/tsconfig.json
+++ b/packages/tile-extruder-web-app/tsconfig.json
@@ -11,8 +11,8 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
     "incremental": true,
+    "jsx": "preserve",
     "plugins": [
       {
         "name": "next"
@@ -22,6 +22,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "src/**/*.tsx?", "types/**/*.ts", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "src/**/*",  "types/**/*", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/tile-extruder-web-app/tsconfig.json
+++ b/packages/tile-extruder-web-app/tsconfig.json
@@ -11,8 +11,8 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "incremental": true,
     "jsx": "preserve",
+    "incremental": true,
     "plugins": [
       {
         "name": "next"
@@ -22,6 +22,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "src/**/*",  "types/**/*", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "src/**/*", "types/**/*", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
# Description

Had a few users beta test the web app and bundling some fixes together here

## What changed

- fix bad bug in extrusion form. If you change input settings many times in a row (e.g. focus the tile width input => hold up arrow), you can crash the web app. The issue is that too many webgl context are being held in memory b/c of improper cleanup, so some contexts can get dropped. The root issue was that the output canvas was conditionally rendered, and when it was unmounted, it wasn't having its shader cleanup logic run. Created `packages/tile-extruder-web-app/src/app/components/WebGL2Canvas.tsx` to solve for this
- info page => links open in new tab (`packages/tile-extruder-web-app/src/app/info/page.tsx`)
- `packages/tile-extruder-web-app/tsconfig.json` borked the TS setup in the last PR such that TSX files weren't being included

## Test plan

- click links on info, should open in new page
- load an image => change inputs quickly => shouldn't crash

https://github.com/user-attachments/assets/8150da02-d6ba-4f3f-be2a-d998f9affb2a


